### PR TITLE
Use npm publish --access public

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
### What did you change/add/fix?

Use `npm publish --access public` as our package name has our company prefix.

### Related links (github issue, sentry, google docs, slack conversation)

### What testing you did?

None
